### PR TITLE
refactor: rename date columns for clarity in analytics models

### DIFF
--- a/models/analytics/analytics_daily_denial_reasons.sql
+++ b/models/analytics/analytics_daily_denial_reasons.sql
@@ -7,7 +7,7 @@ select
     , document_sub_category
     , document_category_step
     , document_tenant_type
-    , DATE(document_denied_at) as document_denied_date
+    , DATE(document_denied_at) as denial_date
     , COUNT(document_id) as nb_denied_documents
 from {{ ref('core_document_denied_reasons') }}
 group by

--- a/models/analytics/analytics_daily_operations.sql
+++ b/models/analytics/analytics_daily_operations.sql
@@ -1,5 +1,5 @@
 select
-    DATE(created_at) as created_date
+    DATE(created_at) as operation_date
     , SUM(case when log_type in ('ACCOUNT_DENIED', 'ACCOUNT_VALIDATED') then 1 else 0 end) as nb_operation
     , SUM(case when log_type = 'ACCOUNT_DENIED' then 1 else 0 end) as nb_denied
     , SUM(case when log_type = 'ACCOUNT_VALIDATED' then 1 else 0 end) as nb_validation

--- a/models/analytics/analytics_daily_owner_account.sql
+++ b/models/analytics/analytics_daily_owner_account.sql
@@ -1,5 +1,5 @@
 select
-    DATE(created_at) as created_date
+    DATE(created_at) as creation_date
     , COUNT(id) as nb_creation
     , SUM(nb_property_created) as nb_property_created
 from {{ ref('core_owner_account') }}

--- a/models/analytics/analytics_daily_property_operations.sql
+++ b/models/analytics/analytics_daily_property_operations.sql
@@ -1,5 +1,5 @@
 select
-    DATE(created_at) as created_date
+    DATE(created_at) as creation_date
     , SUM(case when log_type = 'APPLICATION_DELETED_BY_OWNER' then 1 else 0 end) as application_deleted_by_owner
     , SUM(case when log_type = 'APPLICATION_PAGE_VISITED' then 1 else 0 end) as application_page_visited
     , SUM(case when log_type = 'APPLICATION_RECEIVED' then 1 else 0 end) as application_received

--- a/models/analytics/analytics_daily_tenant_account.sql
+++ b/models/analytics/analytics_daily_tenant_account.sql
@@ -3,7 +3,7 @@ select
     , funnel_type
     , tenant_type
     , status as tenant_status
-    , DATE(created_at) as created_date
+    , DATE(created_at) as creation_date
     , COUNT(id) as nb_creation
     , SUM(is_france_connected::INTEGER) as nb_france_connected
     , SUM(completion_flag) as nb_account_completions


### PR DESCRIPTION
Updated column names for date fields in multiple analytics SQL models to improve clarity:
- `document_denied_date` to `denial_date` in `analytics_daily_denial_reasons.sql`
- `created_date` to `operation_date` in `analytics_daily_operations.sql`
- `created_date` to `creation_date` in `analytics_daily_owner_account.sql`, `analytics_daily_property_operations.sql`, and `analytics_daily_tenant_account.sql`.