### PR TITLE
fix: denied operation count in denial reasons report

### DIFF
--- a/models/analytics/analytics_daily_denial_reasons.sql
+++ b/models/analytics/analytics_daily_denial_reasons.sql
@@ -22,7 +22,7 @@ with daily_denial_reasons as (
 , daily_operations as (
     select
         DATE(operation_hour) as operation_date
-        , SUM(nb_operation) as nb_operation
+        , SUM(nb_denied) as nb_denied
     from {{ ref('analytics_hourly_operations') }}
     group by
         DATE(operation_hour)
@@ -30,7 +30,7 @@ with daily_denial_reasons as (
 
 select
     daily_denial_reasons.*
-    , daily_operations.nb_operation
+    , daily_operations.nb_denied
 from daily_denial_reasons
 left join daily_operations
     on daily_denial_reasons.denial_date = daily_operations.operation_date


### PR DESCRIPTION
Updates the daily denial reasons report to accurately reflect the number of denials by using the `nb_denied` column instead of the `nb_operation` column from the `analytics_hourly_operations` model.